### PR TITLE
Adding the changes for segregation of PHP & html code from controller to template

### DIFF
--- a/view/frontend/templates/checkout/shipping/parcelshop-marker.phtml
+++ b/view/frontend/templates/checkout/shipping/parcelshop-marker.phtml
@@ -1,0 +1,36 @@
+<?php
+$markerParams = $block->getData('markerParams');
+$shop = $markerParams['shop'];
+$special = $markerParams['special'];
+$image = $markerParams['image'];
+$openingHoursHtml = $markerParams['openingHoursHtml'];
+?>
+<div class="content">
+    <table style="min-width: 380px" cellpadding="3" cellspacing="3">
+        <tbody>
+            <tr>
+                <td style="padding: 3px; padding-right: 15px;" rowspan="2">
+                    <img class="parcelshoplogo bubble" style="width: 80px; height: 80px;" src="<?= $image ?>" alt="DPD Parcelshop logo" />
+                </td>
+                <td style="padding: 3px; padding-top: 6px; width: 100%;" colspan="3">
+                    <strong><?= ($special ? $shop['getParcelshopPudoName']() : $shop['company']) ?></strong><br />
+                    <?= ($special ? $shop['getData']('parcelshop_address_1') : $shop['street'] . " " . $shop['houseNo']) . '<br />
+                                ' . ($special ? $shop['getParcelshopPostCode']() . ' ' . $shop['getParcelshopTown']() : $shop['zipCode'] . ' ' . $shop['city']) ?>
+                </td>
+            </tr>
+            <tr>
+                <td style="padding: 3px; padding-top: 6px; width: 100%;" colspan="3">
+                    <strong>Openingstijden</strong>
+                </td>
+            </tr>
+             <?= $openingHoursHtml; ?>
+            <tr>
+                <td style="padding: 3px; border: none;"></td>
+                <td style="padding: 3px; width: 100%;" colspan="3">
+                    <a class="parcelshoplink" id="<?= ($special ? $shop['getParcelshopDelicomId']() : $shop['parcelShopId']) ?>" href="#"> <?= __('Select Parcelshop') ?></a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+

--- a/view/frontend/templates/checkout/shipping/parcelshop-opening-hours.phtml
+++ b/view/frontend/templates/checkout/shipping/parcelshop-opening-hours.phtml
@@ -1,0 +1,12 @@
+<?php
+$openingHours =  $block->getData('openingHours');
+$openingHoursMorning = $openingHours['openingHoursMorning'];
+$openingHoursAfternoon= $openingHours['openingHoursAfternoon'];
+$weekday = $openingHours['weekday'];
+?>
+<tr>
+    <td style="padding: 3px; border: none;"></td>
+    <td style="padding: 3px; width: 33%;"><strong><?= __(strtolower($weekday)) ?></strong></td>
+    <td style="padding: 3px; width: 33%; text-align: center;"><?= $openingHoursMorning ?></td>
+    <td style="padding: 3px; width: 33%; text-align: center;"><?= $openingHoursAfternoon ?></td>
+</tr>


### PR DESCRIPTION
Hello Team @dpdplugin ,

We have done the changes for segregating the PHP and HTML code from the Controller file Index.php to the two template files. We have divided the HTML code in two separate phtml files (**parcelshop-marker.phtml & parcelshop-opening-hours.phtml**). We have taken the reference of Single-responsibility Principle from SOLID principles. By using this way, controller will be responsible only for routing, some part of calculation and not for rendering the HTML code. Please let us know your suggestions on this and also let us know if anything is required from our end.

Thanks,
Parth

