### PR TITLE
Make extension Magento 2.4.x ready

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "DPD Connect - Magento2 Shipping",
     "require": {
         "php": ">=7.0.13",
-        "magento/framework": "^100.0|^101.0|^102.0",
+        "magento/framework": "^100.0|^101.0|^102.0|^103.0",
         "dpdconnect/php-sdk": "^1.0"
     },
     "type": "magento2-module",


### PR DESCRIPTION
The extension has been updated to make it compatible with Magento
2.4.x. A newer version of the Magento framework is now used for this
extension.