### PR TITLE
Add scope when fetching tablerate condition

### DIFF
--- a/Model/Carrier/DpdClassic.php
+++ b/Model/Carrier/DpdClassic.php
@@ -143,7 +143,11 @@ class DpdClassic extends AbstractCarrier implements
                 $request->setPackageValue($oldValue - $freePackageValue);
             }
 
-            $conditionName = $this->_scopeConfig->getValue('carriers/dpdclassic/condition_name', \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE);
+            $conditionName = $this->_scopeConfig->getValue(
+                'carriers/dpdclassic/condition_name',
+                \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE,
+                $request->getWebsiteId()
+            );
             $request->setConditionName($conditionName ? $conditionName : $this->_defaultConditionName);
 
             // Package weight and qty free shipping

--- a/Model/Carrier/DpdClassicSaturday.php
+++ b/Model/Carrier/DpdClassicSaturday.php
@@ -203,7 +203,11 @@ class DpdClassicSaturday extends AbstractCarrier implements
                 $request->setPackageValue($oldValue - $freePackageValue);
             }
 
-            $conditionName = $this->_scopeConfig->getValue('carriers/dpdclassicsaturday/condition_name', \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE);
+            $conditionName = $this->_scopeConfig->getValue(
+                'carriers/dpdclassicsaturday/condition_name',
+                \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE,
+                $request->getWebsiteId()
+            );
             $request->setConditionName($conditionName ? $conditionName : $this->_defaultConditionName);
 
             // Package weight and qty free shipping

--- a/Model/Carrier/DpdExpress10.php
+++ b/Model/Carrier/DpdExpress10.php
@@ -145,7 +145,11 @@ class DpdExpress10 extends AbstractCarrier implements
                 $request->setPackageValue($oldValue - $freePackageValue);
             }
 
-            $conditionName = $this->_scopeConfig->getValue('carriers/dpdexpress10/condition_name', \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE);
+            $conditionName = $this->_scopeConfig->getValue(
+                'carriers/dpdexpress10/condition_name',
+                \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE,
+                $request->getWebsiteId()
+            );
             $request->setConditionName($conditionName ? $conditionName : $this->_defaultConditionName);
 
             // Package weight and qty free shipping

--- a/Model/Carrier/DpdExpress12.php
+++ b/Model/Carrier/DpdExpress12.php
@@ -144,7 +144,11 @@ class DpdExpress12 extends AbstractCarrier implements
                 $request->setPackageValue($oldValue - $freePackageValue);
             }
 
-            $conditionName = $this->_scopeConfig->getValue('carriers/dpdexpress12/condition_name', \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE);
+            $conditionName = $this->_scopeConfig->getValue(
+                'carriers/dpdexpress12/condition_name',
+                \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE,
+                $request->getWebsiteId()
+            );
             $request->setConditionName($conditionName ? $conditionName : $this->_defaultConditionName);
 
             // Package weight and qty free shipping

--- a/Model/Carrier/DpdGuarantee18.php
+++ b/Model/Carrier/DpdGuarantee18.php
@@ -144,7 +144,11 @@ class DpdGuarantee18 extends AbstractCarrier implements
                 $request->setPackageValue($oldValue - $freePackageValue);
             }
 
-            $conditionName = $this->_scopeConfig->getValue('carriers/dpdguarantee18/condition_name', \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE);
+            $conditionName = $this->_scopeConfig->getValue(
+                'carriers/dpdguarantee18/condition_name',
+                \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE,
+                $request->getWebsiteId()
+            );
             $request->setConditionName($conditionName ? $conditionName : $this->_defaultConditionName);
 
             // Package weight and qty free shipping

--- a/Model/Carrier/DpdSaturday.php
+++ b/Model/Carrier/DpdSaturday.php
@@ -179,7 +179,11 @@ class DpdSaturday extends AbstractCarrier implements
                 $request->setPackageValue($oldValue - $freePackageValue);
             }
 
-            $conditionName = $this->_scopeConfig->getValue('carriers/dpdsaturday/condition_name', \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE);
+            $conditionName = $this->_scopeConfig->getValue(
+                'carriers/dpdsaturday/condition_name',
+                \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE,
+                $request->getWebsiteId()
+            );
             $request->setConditionName($conditionName ? $conditionName : $this->_defaultConditionName);
 
             // Package weight and qty free shipping

--- a/Model/Carrier/Dpdpickup.php
+++ b/Model/Carrier/Dpdpickup.php
@@ -144,7 +144,11 @@ class Dpdpickup extends AbstractCarrier implements
                 $request->setPackageValue($oldValue - $freePackageValue);
             }
 
-            $conditionName = $this->_scopeConfig->getValue('carriers/dpdpickup/condition_name', \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE);
+            $conditionName = $this->_scopeConfig->getValue(
+                'carriers/dpdpickup/condition_name',
+                \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE,
+                $request->getWebsiteId()
+            );
             $request->setConditionName($conditionName ? $conditionName : $this->_defaultConditionName);
 
             // Package weight and qty free shipping

--- a/Model/Carrier/Dpdpredict.php
+++ b/Model/Carrier/Dpdpredict.php
@@ -143,7 +143,11 @@ class Dpdpredict extends AbstractCarrier implements \Magento\Shipping\Model\Carr
                 $request->setPackageValue($oldValue - $freePackageValue);
             }
 
-            $conditionName = $this->_scopeConfig->getValue('carriers/dpdpredict/condition_name', \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE);
+            $conditionName = $this->_scopeConfig->getValue(
+                'carriers/dpdpredict/condition_name',
+                \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE,
+                $request->getWebsiteId()
+            );
             $request->setConditionName($conditionName ? $conditionName : $this->_defaultConditionName);
 
             // Package weight and qty free shipping


### PR DESCRIPTION
We had issues adding order comments via REST API.

Steps to reproduce:
1. Configure dpd pickup on website level only with tablerates.
2. Place order
3. Try to add order comment via API.

```BASH
curl -X POST "https://localhost/rest/all/V1/orders/1/comments" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: Bearer <token>" -d "{ \"statusHistory\": { \"comment\": \"api\" }}"
```