### PR TITLE
getFreeShipping isn't guaranteed to be a boolean

### DIFF
--- a/Model/Carrier/Dpd.php
+++ b/Model/Carrier/Dpd.php
@@ -379,7 +379,7 @@ class Dpd extends AbstractCarrier implements
             $rate = $this->getRate($request);
 
             $shippingPrice = $rate['price'];
-            if (true === $request->getFreeShipping()) {
+            if ($request->getFreeShipping()) {
                 $shippingPrice = 0;
             }
 
@@ -396,7 +396,7 @@ class Dpd extends AbstractCarrier implements
             $amount = $this->getConfigData('price');
         }
 
-        if (true === $request->getFreeShipping()) {
+        if ($request->getFreeShipping()) {
             $amount = 0;
         }
 


### PR DESCRIPTION
For proof in Magento 2.4 see: https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Quote/Model/Quote/Address.php#L1066 for the location where the request gets filled with the address' getFreeShipping() value. When this value is filled by, for example, https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Quote/Model/Quote/Address/Total/Shipping.php#L76 you can see that the value of free shipping on the address is explicitly set to be an integer.

By removing the strict comparison and relying on PHP's built-in truthiness free shipping will work more as expected.

In practical terms this change fixes a bug where free shipping price rules didn't effect DPD shipping methods