### PR TITLE
Fix layout overrides

### DIFF
--- a/view/adminhtml/layout/adminhtml_order_shipment_new.xml
+++ b/view/adminhtml/layout/adminhtml_order_shipment_new.xml
@@ -7,27 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="admin.scope.col.wrap" htmlClass="admin__old" /> <!-- ToDo UI: remove this wrapper with old styles removal. The class name "admin__old" is for tests only, we shouldn't use it in any way -->
-        <referenceContainer name="content">
-            <block class="Magento\Shipping\Block\Adminhtml\Create" name="sales_shipment_create">
-                <block class="Magento\Shipping\Block\Adminhtml\Create\Form" name="form" template="Magento_Shipping::create/form.phtml">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="Magento_Sales::order/view/info.phtml">
-                        <container name="extra_customer_info"/>
-                    </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <container name="extra_shipment_info"/>
-                    <block class="Magento\Shipping\Block\Adminhtml\Create\Items" name="order_items" template="Magento_Shipping::create/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" name="default" as="default" template="Magento_Shipping::create/items/renderer/default.phtml"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
-                        <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-                        <container name="submit_before" label="Submit Before"/>
-                        <container name="submit_after" label="Submit After"/>
-                    </block>
-                    <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking" name="shipment_tracking" template="Magento_Shipping::order/tracking.phtml"/>
-                    <block class="DpdConnect\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packaging" template="DpdConnect_Shipping::order/packaging/popup.phtml"/>
-                </block>
-            </block>
-        </referenceContainer>
+        <referenceBlock class="DpdConnect\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packaging" template="DpdConnect_Shipping::order/packaging/popup.phtml"/>
     </body>
 </page>

--- a/view/adminhtml/layout/adminhtml_order_shipment_view.xml
+++ b/view/adminhtml/layout/adminhtml_order_shipment_view.xml
@@ -7,27 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="admin.scope.col.wrap" htmlClass="admin__old" /> <!-- ToDo UI: remove this wrapper with old styles removal. The class name "admin__old" is for tests only, we shouldn't use it in any way -->
-        <referenceContainer name="content">
-            <block class="Magento\Shipping\Block\Adminhtml\View" name="sales_shipment_view">
-                <block class="Magento\Shipping\Block\Adminhtml\View\Form" name="form" template="Magento_Shipping::view/form.phtml">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="Magento_Sales::order/view/info.phtml">
-                        <container name="extra_customer_info"/>
-                    </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <container name="extra_shipment_info"/>
-                    <block class="Magento\Shipping\Block\Adminhtml\View\Items" name="shipment_items" template="Magento_Shipping::view/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" name="default" as="default" template="Magento_Shipping::view/items/renderer/default.phtml"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
-                        <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-                    </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="Magento_Sales::order/comments/view.phtml"/>
-                    <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\View" name="shipment_tracking" template="Magento_Shipping::order/tracking/view.phtml"/>
-                    <block class="DpdConnect\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packaging" template="DpdConnect_Shipping::order/packaging/popup.phtml"/>
-                    <block class="Magento\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packed" template="Magento_Shipping::order/packaging/packed.phtml"/>
-                </block>
-            </block>
-        </referenceContainer>
+        <referenceBlock class="DpdConnect\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packaging" template="DpdConnect_Shipping::order/packaging/popup.phtml"/>
     </body>
 </page>


### PR DESCRIPTION
Currently the layouts `adminhtml_order_shipment_new.xml` and `adminhtml_order_shipment_view.xml` override the complete layout instead of just updating what needs to be changed. Because of this, Multi Source Inventory, for example, does not work.