### PR TITLE
Get correct DPD Parcelshop name when using Picqer mode

### DIFF
--- a/Observer/SalesOrderAddressSaveBefore.php
+++ b/Observer/SalesOrderAddressSaveBefore.php
@@ -79,7 +79,7 @@ class SalesOrderAddressSaveBefore implements ObserverInterface
         if($this->scopeConfig->getValue('dpdshipping/account_settings/picqer_mode')) {
             $shippingAddress->setFirstname($order->getBillingAddress()->getFirstname());
             $shippingAddress->setLastname($order->getBillingAddress()->getLastname());
-            $shippingAddress->setCompany('DPD ParcelShop: ' . $order->getDpdCompany());
+            $shippingAddress->setCompany('DPD ParcelShop: ' . $order->getDpdParcelshopName());
         }
 
         // empty this otherwise you'd get customer data and DPD parcelshop data mixed up


### PR DESCRIPTION
Currently `$order->getDpdCompany()` returns `null` while the following fields `dpd_parcelshop_id` and `dpd_parcelshop_name` have correct parcelshop data.

I believe `$order->getDpdCompany()` should be `$order->getDpdParcelshopName()` to be in line with the refactor from release `1.2.0`.