### PR TITLE
Fix constant name ADMIN_RESOURCE in TestConnection controller

### DIFF
--- a/Controller/Adminhtml/Search/System/Config/TestConnection.php
+++ b/Controller/Adminhtml/Search/System/Config/TestConnection.php
@@ -32,7 +32,7 @@ use Magento\Store\Model\StoreManagerInterface;
 class TestConnection extends Action implements HttpPostActionInterface
 {
     /** @var string  */
-    public const string ADMIN_RESOURCE = 'Magento_Catalog::config_catalog';
+    public const ADMIN_RESOURCE = 'Magento_Catalog::config_catalog';
 
     /**
      * @param Context $context


### PR DESCRIPTION
Compilation issue on magento 2.4.6-p10 and php8.2
Fixes a constant naming issue in `TestConnection.php`.

Error : unexpected variable "string"

❌ Before:
`public const ADMINRESOURCE = 'Magento_Catalog::config_catalog';`

✅ After:
`public const ADMIN_RESOURCE = 'Magento_Catalog::config_catalog';`