### PR TITLE
Solve create label for dpdpickup

### DIFF
--- a/Observer/SalesOrderSaveBefore.php
+++ b/Observer/SalesOrderSaveBefore.php
@@ -109,7 +109,7 @@ class SalesOrderSaveBefore implements ObserverInterface
             $order->setDpdParcelshopCountry($quote->getData('dpd_parcelshop_country'));
         }
 
-        if ('dpd_dpd' === $order->getShippingMethod()) {
+        if (in_array($order->getShippingMethod(), ['dpd_dpd', 'dpdpickup_dpdpickup'])) {
             $order->setDpdShippingProduct($quote->getData('dpd_shipping_product'));
         }
     }


### PR DESCRIPTION
Currently it is not possible to create a shipping label for pickup point orders, because the dpd shipping product is not set.

This fix will solve this.