### PR TITLE
Add resilience to DPD API calls with try-catch and HTTP timeouts

### DIFF
--- a/Block/Adminhtml/System/Carrier/DpdCustomerProductSettings.php
+++ b/Block/Adminhtml/System/Carrier/DpdCustomerProductSettings.php
@@ -88,7 +88,11 @@ class DpdCustomerProductSettings extends Field
      */
     public function getCustomerProducts()
     {
-        $products = $this->DPDClient->authenticate()->getProduct()->getList();
+        try {
+            $products = $this->DPDClient->authenticate()->getProduct()->getList();
+        } catch (\Exception $e) {
+            return [];
+        }
 
         return array_filter($products, function($product) {
             return in_array($product['type'], ['b2b', 'predict']);

--- a/Controller/Parcelshops/Index.php
+++ b/Controller/Parcelshops/Index.php
@@ -145,7 +145,13 @@ class Index extends \Magento\Framework\App\Action\Action
             'limit' => $this->dpdSettings->getValue(DpdSettings::PARCELSHOP_MAPS_SHOPS)
         ];
 
-        $parcelShops = $this->dpdClient->authenticate()->getParcelshop()->getList($coordinates);
+        try {
+            $parcelShops = $this->dpdClient->authenticate()->getParcelshop()->getList($coordinates);
+        } catch (\Exception $e) {
+            $resultData['success'] = false;
+            $resultData['error_message'] = __('DPD parcelshop service is temporarily unavailable. Please try again later.');
+            return $result->setData($resultData);
+        }
 
         $params = array('_secure' => $this->getRequest()->isSecure());
 

--- a/Helper/DPDClient.php
+++ b/Helper/DPDClient.php
@@ -24,6 +24,7 @@ use DpdConnect\Sdk\Objects\ObjectFactory;
 use DpdConnect\Sdk\Objects\MetaData;
 use DpdConnect\Sdk\ClientBuilder;
 use DpdConnect\Sdk\Client;
+use DpdConnect\Sdk\Common\HttpClient;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Encryption\Encryptor;
 use Magento\Framework\App\ProductMetadataInterface;
@@ -91,11 +92,17 @@ class DPDClient extends AbstractHelper
         $pluginVersion = $this->moduleList
             ->getOne(self::MODULE_NAME)['setup_version'];
 
-        $clientBuiler = new ClientBuilder($url, ObjectFactory::create(MetaData::class, [
+        $meta = ObjectFactory::create(MetaData::class, [
             'webshopType' => $this->productMetadata->getName() . ' ' . $this->productMetadata->getEdition(),
             'webshopVersion' => $this->productMetadata->getVersion(),
             'pluginVersion' => $pluginVersion,
-        ]));
+        ]);
+
+        $clientBuiler = new ClientBuilder($url, $meta);
+
+        $endpoint = $clientBuiler->getEndpoint() ?: Client::ENDPOINT;
+        $httpClient = new HttpClient($endpoint, 5, 2);
+        $clientBuiler->setHttpClient($httpClient);
 
         $client = $clientBuiler->buildAuthenticatedByPassword(
             $this->dpdSettings->getValue(DpdSettings::ACCOUNT_USERNAME,ScopeInterface::SCOPE_STORE, $storeId),

--- a/Helper/Services/OrderService.php
+++ b/Helper/Services/OrderService.php
@@ -120,7 +120,11 @@ class OrderService extends AbstractHelper
             return Constants::CARRIER_PARCELSHOP === $this->order->getShippingMethod();
         }
 
-        $availableProducts = $this->DPDClient->authenticate()->getProduct()->getList();
+        try {
+            $availableProducts = $this->DPDClient->authenticate()->getProduct()->getList();
+        } catch (\Exception $e) {
+            return Constants::CARRIER_PARCELSHOP === $this->order->getShippingMethod();
+        }
         $selectedCode = $this->getSelectedCode();
 
         $selectedProduct = null;

--- a/Model/Attribute/Source/ShippingType.php
+++ b/Model/Attribute/Source/ShippingType.php
@@ -25,21 +25,25 @@ class ShippingType extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSo
     public function getAllOptions()
     {
         if (!$this->_options) {
-            $availableProducts = $this->client->authenticate()->getProduct()->getList();
-            $availableCodes = array_map(function($product) {
-                return $product['code'];
-            }, $availableProducts);
-
             $this->_options = [
                 ['label' => __('Default'), 'value' => 'default'],
             ];
 
-            if (true === in_array('FRESH', $availableCodes)) {
-                $this->_options[] = ['label' => __('Fresh'), 'value' => 'fresh'];
-            }
+            try {
+                $availableProducts = $this->client->authenticate()->getProduct()->getList();
+                $availableCodes = array_map(function($product) {
+                    return $product['code'];
+                }, $availableProducts);
 
-            if (true === in_array('FREEZE', $availableCodes)) {
-                $this->_options[] = ['label' => __('Freeze'), 'value' => 'freeze'];
+                if (true === in_array('FRESH', $availableCodes)) {
+                    $this->_options[] = ['label' => __('Fresh'), 'value' => 'fresh'];
+                }
+
+                if (true === in_array('FREEZE', $availableCodes)) {
+                    $this->_options[] = ['label' => __('Freeze'), 'value' => 'freeze'];
+                }
+            } catch (\Exception $e) {
+                // DPD API unavailable — return only the default option
             }
         }
 

--- a/Model/CheckoutConfigProvider.php
+++ b/Model/CheckoutConfigProvider.php
@@ -25,6 +25,7 @@ use DpdConnect\Shipping\Helper\DPDClient;
 use DpdConnect\Shipping\Helper\DpdSettings;
 use Magento\Framework\Encryption\Encryptor;
 use Magento\Framework\UrlInterface;
+use Psr\Log\LoggerInterface;
 
 class CheckoutConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
 {
@@ -64,6 +65,11 @@ class CheckoutConfigProvider implements \Magento\Checkout\Model\ConfigProviderIn
     private $localeResolver;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * CheckoutConfigProvider constructor.
      *
      * @param UrlInterface $urlBuilder
@@ -72,6 +78,8 @@ class CheckoutConfigProvider implements \Magento\Checkout\Model\ConfigProviderIn
      * @param DpdSettings $dpdSettings
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param \Magento\Framework\Locale\Resolver $localeResolver
+     * @param LoggerInterface $logger
      */
     public function __construct(
         UrlInterface $urlBuilder,
@@ -80,7 +88,8 @@ class CheckoutConfigProvider implements \Magento\Checkout\Model\ConfigProviderIn
         DpdSettings $dpdSettings,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Checkout\Model\Session $checkoutSession,
-        \Magento\Framework\Locale\Resolver $localeResolver
+        \Magento\Framework\Locale\Resolver $localeResolver,
+        LoggerInterface $logger
     ) {
         $this->urlBuilder = $urlBuilder;
         $this->scopeConfig = $scopeConfig;
@@ -89,6 +98,7 @@ class CheckoutConfigProvider implements \Magento\Checkout\Model\ConfigProviderIn
         $this->crypt = $crypt;
         $this->checkoutSession = $checkoutSession;
         $this->localeResolver = $localeResolver;
+        $this->logger = $logger;
     }
 
     /**
@@ -124,7 +134,22 @@ class CheckoutConfigProvider implements \Magento\Checkout\Model\ConfigProviderIn
         $dayOfWeek = date('N');
         $availableShippingProducts = [];
         $shippingProductsConfig = $this->dpdSettings->getDpdCarrierCustomerProductSettings();
-        $shippingProducts = $this->client->authenticate()->getProduct()->getList();
+        try {
+            $shippingProducts = $this->client->authenticate()->getProduct()->getList();
+        } catch (\Exception $exception) {
+            // When DPD API is unreachable, disable DPD shipping methods gracefully
+            // so the rest of the checkout keeps working
+            $this->logger->warning('DPD API unavailable, disabling DPD shipping methods in checkout: ' . $exception->getMessage());
+            $output['dpd_carrier_save_url'] = $this->urlBuilder->getUrl('dpd/carrier/save', ['_secure' => true]);
+            $output['dpd_carrier_available_shipping_products'] = [];
+
+            $locale = $this->localeResolver->getLocale();
+            $localeParts = explode('_', $locale);
+            $languageCode = $localeParts[0];
+            $output['dpd_locale'] = $languageCode;
+
+            return $output;
+        }
         foreach($shippingProducts as $product) {
             // Handle no selected days as all selected
             if (!isset($shippingProductsConfig[$product['code']]['days'])) {

--- a/ViewModel/CheckShipment.php
+++ b/ViewModel/CheckShipment.php
@@ -126,7 +126,11 @@ class CheckShipment implements ArgumentInterface
      */
     public function getParcelshopCode()
     {
-        $availableProducts = $this->client->authenticate()->getProduct()->getList();
+        try {
+            $availableProducts = $this->client->authenticate()->getProduct()->getList();
+        } catch (\Exception $e) {
+            throw new \Exception('DPD API is currently unavailable');
+        }
         foreach($availableProducts as $product) {
             if ('parcelshop' === $product['type']) {
                 return $product['code'];
@@ -145,7 +149,11 @@ class CheckShipment implements ArgumentInterface
     public function getLabelTypeOptions(Order $order)
     {
         $availableProducts = [];
-        $shippingProducts = $this->client->authenticate()->getProduct()->getList();
+        try {
+            $shippingProducts = $this->client->authenticate()->getProduct()->getList();
+        } catch (\Exception $e) {
+            return [];
+        }
         foreach($shippingProducts as $shippingProduct) {
             if ('fresh' === $shippingProduct['type']
                 || ('parcelshop' === $shippingProduct['type'] && !$this->isParcelshopOrder($order))


### PR DESCRIPTION
Yesterday, the Kubernetes cluster DPD runs their authentication and config provision on went down for a period of about 2-3 hours;

<img width="922" height="474" alt="image" src="https://github.com/user-attachments/assets/8073d5c8-80d6-4b77-baa9-6d7f42bfb2d6" />

Our checkout and cart went down with it as well because the hung hang while trying to do requests to the DPD platform.

This PR aims to solve that problem by;

- Wrapping all DPD API calls in try-catch blocks so the checkout and admin keep working when the DPD API is unreachable. 
- Adding HTTP client with 5s timeout and 2 retries to prevent long hangs.