### PR TITLE
Correct weight on label when using multi-parcel

### DIFF
--- a/Helper/Services/OrderConvertService.php
+++ b/Helper/Services/OrderConvertService.php
@@ -216,6 +216,11 @@ class OrderConvertService extends AbstractHelper
             if ($unit === 'POUND') {
                 $weight = $weight * 0.45359237;
             }
+	    
+	    if ($unit === 'KILOGRAM') {
+	        // Weight is in KG so multiply with 100		    
+		$weight *= 100;
+            }
 
             $volume = empty($package['params']['package_type'])
                 ? $this->dpdSettings->getDefaultPackageType()


### PR DESCRIPTION
When you create a multi-parcel order with the weight in kg, the code is missing the weight*100 to send the correct value to the DPD API. This results in a wrong value on the label, ex 31Kg becomes 0,31 Kg

The calculation does exist in getOrderWeight(), but that function isn't used in addParcelsFromPackages()