### PR TITLE
Critical exteptions handling

### DIFF
--- a/Model/ResourceModel/Tablerate.php
+++ b/Model/ResourceModel/Tablerate.php
@@ -298,7 +298,7 @@ class Tablerate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function uploadAndImport(\Magento\Framework\DataObject $object)
     {
-        foreach ($_FILES['groups']['tmp_name'] as $key => $value) {
+        foreach ($_FILES['groups']['tmp_name'] ?? [] as $key => $value) {
             // Only process uploaded DPD files
             if (strpos($key, 'dpd') !== 0) {
                 continue;


### PR DESCRIPTION
## Handle undefined $_FILES in uploadAndImport method
When there are more shipping methods than just DPD, exception is thrown while trying to save config.
This change ensures undefined array key is falled back to empty array, thus not breaking the logic
