### PR TITLE
Fixes for PHP 8.5 by removing deprecated code.

### DIFF
--- a/Model/ResourceModel/Tablerate.php
+++ b/Model/ResourceModel/Tablerate.php
@@ -607,7 +607,7 @@ class Tablerate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         if (!is_numeric($value)) {
             return false;
         }
-        $value = (double)sprintf('%.4F', $value);
+        $value = (float)sprintf('%.4F', $value);
         if ($value < 0.0000) {
             return false;
         }

--- a/Services/GoogleMaps.php
+++ b/Services/GoogleMaps.php
@@ -84,7 +84,6 @@ class GoogleMaps
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $response = curl_exec($ch);
-        curl_close($ch);
 
         return json_decode($response);
     }


### PR DESCRIPTION
2 changes:
- casting to `double` [is deprecated](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.non-canonical-cast-names) in favour of casting to `float`
- Calling `curl_close` [is deprecated](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.curl), it's fine to fully remove this line as [it didn't do anything since PHP 8.0](https://www.php.net/manual/en/function.curl-close.php#:~:text=Note%3A%20This%20function%20has%20no%20effect.%20Prior%20to%20PHP%208.0.0%2C%20this%20function%20was%20used%20to%20close%20the%20resource.) and your module requires PHP 8.1 at the minimum

In addition, this PR is also needed: https://github.com/dpdconnect/php-sdk/pull/33

@dpdplugin, if you have a bit of time, it would be appreciated if this can be merged soon-ish as we're preparing an upgrade to Magento 2.4.9 with PHP 8.5 and this module stops us from being able to.

Thanks!